### PR TITLE
Fix: Log 500 HTTP responses as ERROR in API (#1299)

### DIFF
--- a/packages/logging/src/hono/http-logger/http-logger.service.ts
+++ b/packages/logging/src/hono/http-logger/http-logger.service.ts
@@ -51,7 +51,11 @@ export class HttpLoggerIntercepter {
           log.userId = currentUser.id;
         }
 
-        this.logger?.info(log);
+        if (c.res.status >= 500) {
+          this.logger?.error(log);
+        } else {
+          this.logger?.info(log);
+        }
       }
     };
   }


### PR DESCRIPTION
Addresses #1299

**Problem:**
Previously, the API service logged HTTP responses with a 500 status code using the "INFO" severity level. This is incorrect for error monitoring systems which expect 5xx errors to be logged at an "ERROR" level.

**Solution:**
This pull request modifies the HTTP logger interceptor to correctly log responses with a status code of 500 or greater using the `logger.error()` method. Responses with status codes below 500 will continue to be logged at the "INFO" level.

**Changes Made:**
- Updated the logging logic in `packages/logging/src/hono/http-logger/http-logger.service.ts`.